### PR TITLE
manifest: Don't track device/generic/uml from AOSP

### DIFF
--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -12,6 +12,7 @@
   <remove-project name="device/generic/qemu" />
   <remove-project name="device/generic/x86" />
   <remove-project name="device/generic/x86_64" />
+  <remove-project name="device/generic/uml" />
   <remove-project name="device/google/accessory/arduino" />
   <remove-project name="device/google/accessory/demokit" />
   <remove-project name="device/google/atv" />


### PR DESCRIPTION
Remove uml_userdebug from lunch menu

Signed-off-by: Anirudh Gupta <anirudhgupta109@gmail.com>
Change-Id: Ib10069bc4da09e53ae35d698141c5827652a7e48